### PR TITLE
Tests/more lexer tests

### DIFF
--- a/src/errors/lex_errors.rs
+++ b/src/errors/lex_errors.rs
@@ -100,43 +100,6 @@ impl CompilerError for UnclosedStringError {
     }
 }
 
-pub struct UnescapedBracketInStringError {
-    actual: char,
-    line_text: &'static str,
-    pos: (usize, usize),
-}
-impl UnescapedBracketInStringError {
-    pub fn new(actual: char, line_text: &'static str, pos: (usize, usize)) -> Self {
-        Self {
-            actual,
-            line_text,
-            pos: (pos.0 + 1, pos.1 + 1),
-        }
-    }
-}
-impl CompilerError for UnescapedBracketInStringError {
-    fn message(&self) -> String {
-        let mut msg: String = "".to_string();
-        msg.push_str(
-            format!(
-                "[SINGLE BRACKET] at line {}, col {}\n",
-                self.pos.0, self.pos.1
-            )
-            .as_str(),
-        );
-        msg.push_str("    Brackets in strings are escaped like: '{{' or '}}'\n");
-        msg.push_str(format!("    Got: '{}'\n", self.actual).as_str());
-        let line_length = self.line_text.len();
-        let border = "-".repeat(line_length);
-        let highlight = " ".repeat(self.pos.1 - 1) + "^";
-        msg.push_str(format!("------{}\n", border).as_str());
-        msg.push_str(format!("{:width$} | {}\n", self.pos.0, self.line_text, width = 3).as_str());
-        msg.push_str(format!("    | {}\n", highlight).as_str());
-        msg.push_str(format!("------{}\n", border).as_str());
-        msg
-    }
-}
-
 pub struct UnclosedCharError {
     actual: char,
     line_text: &'static str,

--- a/src/errors/lex_errors.rs
+++ b/src/errors/lex_errors.rs
@@ -72,10 +72,11 @@ impl CompilerError for UnclosedStringError {
         msg.push_str(
             format!(
                 "    Got: '{}'\n",
-                match self.actual {
-                    '\n' => "NEWLINE".to_string(),
-                    '\r' => "CARRIAGE RETURN".to_string(),
-                    _ => unreachable!(),
+                match &self.actual {
+                    '\n' => "NEWLINE",
+                    '\r' => "CARRIAGE RETURN",
+                    '\0' => "EOF",
+                    _ => unreachable!("unexpected  string terminator: {:?}", &self.actual),
                 }
             )
             .as_str(),

--- a/src/errors/parse_errors.rs
+++ b/src/errors/parse_errors.rs
@@ -5,7 +5,7 @@ use crate::{
     lexer::token::{Token, TokenKind},
     parser::{
         identifiers::{Accessor, Identifier},
-        productions::{AccessType, Param, Production, Range},
+        productions::{AccessType, Param, Production},
     },
     utils::string::StringExt,
 };

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
@@ -311,35 +310,6 @@ impl TokenKind {
     }
 }
 
-pub enum Atoms {
-    AlphaNum,
-    Symbols,
-    Whitespace,
-}
-impl Atoms {
-    pub fn charset(&self) -> HashSet<char> {
-        match self {
-            Self::AlphaNum => ('a'..='z')
-                .chain('A'..='Z')
-                .chain('0'..='9')
-                .chain(HashSet::from(['_']))
-                .collect(),
-            Self::Symbols => HashSet::from([
-                '+', '-', '*', '/', '%', '^', '>', '<', '=', '|', '&', '!', '(', ')', '[', ']',
-                '{', '}', '.', '?', ',', '~', '"', ':',
-            ]),
-            Self::Whitespace => HashSet::from([' ', '\n', '\t', '\r', '\0']),
-        }
-    }
-    pub fn combine(atoms: &[Atoms]) -> HashSet<char> {
-        let mut res = HashSet::new();
-        for atom in atoms {
-            res.extend(atom.charset());
-        }
-        res
-    }
-}
-
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Token {
     pub kind: TokenKind,
@@ -351,7 +321,7 @@ pub struct Token {
 impl Eq for Token {}
 impl PartialEq for Token {
     fn eq(&self, other: &Self) -> bool {
-        self.kind == other.kind
+        self.kind == other.kind && self.text == other.text
     }
 }
 impl fmt::Display for Token {
@@ -366,15 +336,6 @@ impl Hash for Token {
     }
 }
 impl Token {
-    pub fn placeholder(kind: TokenKind) -> Self {
-        Self {
-            kind,
-            text: kind.to_str(),
-            pos: (0, 0),
-            end_pos: (0, 0),
-            range: (0, 0),
-        }
-    }
     pub fn from(
         text: &'static str,
         pos: (usize, usize),

--- a/src/tests/lex_tests.rs
+++ b/src/tests/lex_tests.rs
@@ -337,7 +337,18 @@ fn escaped_escaper_backslash_in_string() {
 }
 
 #[test]
-fn unclosed_string_encountering_eof() {
+fn lexer_errors() {
+    let mut l = Lexer::new("@");
+    l.tokenize();
+    assert!(l.errors.len() == 1);
+    assert!(l.tokens.len() == 0);
+    let first_err = l.errors.first().unwrap();
+    assert!(
+        first_err.starts_with("[UNKNOWN TOKEN '@']"),
+        "Expected [UNKNOWN TOKEN '@'] error\nGot {}",
+        first_err,
+    );
+
     let mut l = Lexer::new(r#"""#);
     l.tokenize();
     assert!(l.errors.len() == 1);
@@ -346,6 +357,17 @@ fn unclosed_string_encountering_eof() {
     assert!(
         first_err.starts_with("[UNCLOSED STRING]"),
         "Expected [UNCLOSED STRING] error\nGot {}",
+        first_err,
+    );
+
+    let mut l = Lexer::new("'");
+    l.tokenize();
+    assert!(l.errors.len() == 1);
+    assert!(l.tokens.len() == 0);
+    let first_err = l.errors.first().unwrap();
+    assert!(
+        first_err.starts_with("[UNCLOSED CHARACTER]"),
+        "Expected [UNCLOSED CHARACTER] error\nGot {}",
         first_err,
     );
 }

--- a/src/tests/lex_tests.rs
+++ b/src/tests/lex_tests.rs
@@ -188,6 +188,27 @@ fn individual_tokens_delimited_by_whitespaces() {
     }
 }
 
-// #[test]
-// fn simple_program() {
-// }
+#[test]
+fn identifiers_with_reserved_words_in_the_name() {
+    let tokens = uwu_tokens()
+        .into_iter()
+        .filter(|tok| {
+            tok.0
+                .starts_with(|ch: char| ch.is_ascii_alphabetic() && ch.is_ascii_lowercase())
+        })
+        .map(|(tok, _)| (tok.to_string() + "a").leak())
+        .collect::<Vec<_>>();
+    for text in tokens {
+        let new_source = text;
+        let mut l = Lexer::new(new_source);
+        l.tokenize();
+        assert!(l.errors.len() == 0);
+        assert!(l.tokens.len() == 1);
+        assert!(
+            l.tokens.first().unwrap().kind == TokenKind::Identifier,
+            "Expected {}\nGot {}",
+            TokenKind::Identifier,
+            l.tokens.first().unwrap().kind
+        );
+    }
+}


### PR DESCRIPTION
closes #9 

---

### new tests
1. identifiers that start with a reserved word must be an identifier
2. escaped `"` inside string must be valid
3. verify token positions
4. tokens are still read even if its delimited by unknown identifier
5. simple testing of expected lexical errors (unknown token, unclosed string, unclosed character)

### other changes
1. removed unused unescaped bracket in string error kind
2. token equality needs to compare the text as well, not just kind