### PR TITLE
Chore/update owo command specs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,3 @@
 name = "OwO"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/src/cli/analyze.rs
+++ b/src/cli/analyze.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::{
     cli::commands::Command,
@@ -6,10 +6,18 @@ use crate::{
 };
 
 pub struct Analyze {
-    pub arg: String,
-    pub flags: Option<Vec<String>>,
+    arg: String,
+    path: PathBuf,
+    flags: Option<Vec<String>>,
 }
 impl Command for Analyze {
+    fn new(arg: String, flags: Option<Vec<String>>) -> Self {
+        Self {
+            arg,
+            path: "".into(),
+            flags,
+        }
+    }
     fn help_msg(verbose: bool) {
         let mut title = "analyze".pad_right(16).fill_left(2).bold();
         if verbose {
@@ -36,15 +44,17 @@ impl Command for Analyze {
             );
         }
     }
-    fn parse(&self) -> Result<(), String> {
-        Path::new(&self.arg)
+    fn validate(&mut self) -> Result<(), String> {
+        self.path = Path::new(&self.arg)
             .canonicalize()
             .map_err(|_| format!("Failed to canonicalize path: '{}'", self.arg))?
-            .must_be_file()?
+            .must_be_file()?;
+        self.path
             .extension()
             .map_or(false, |ext| ext == "uwu")
             .then(|| ())
-            .ok_or(format!("\"{}\" is not a .uwu file", self.arg))
+            .ok_or(format!("\"{}\" is not a .uwu file", self.arg))?;
+        Ok(())
     }
     fn exec(&self) -> Result<(), String> {
         todo!()

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -3,31 +3,45 @@ use crate::cli::{
     version::Version,
 };
 
+/// owo cli command
 pub trait Command {
+    /// This should initialize other fields a command implementor have
+    fn new(arg: String, flags: Option<Vec<String>>) -> Self
+    where
+        Self: Sized;
+    /// Prints a short/verbose message depending on the verbose arg
     fn help_msg(verbose: bool)
     where
         Self: Sized;
-    fn parse(&self) -> Result<(), String>;
+    /// Should validate args and flags, then assign validated values to other fields (if applicable)
+    fn validate(&mut self) -> Result<(), String>;
+    /// Runs the functionality associated to the command
     fn exec(&self) -> Result<(), String>;
 }
-// Put commands here
+/// Tries to convert the passed in args to a [Command] implementor based on the name parameter.
+/// Does not do any sort of validation
 pub fn to_command(
     name: String,
     arg: String,
     flags: Option<Vec<String>>,
 ) -> Result<Box<dyn Command>, String> {
     match name.as_str() {
-        "help" | "" => Ok(Box::new(Help { arg, flags })),
-        "version" => Ok(Box::new(Version { arg, flags })),
-        "lex" => Ok(Box::new(Lex { arg, flags })),
-        "parse" => Ok(Box::new(Parse { arg, flags })),
-        "analyze" => Ok(Box::new(Analyze { arg, flags })),
-        "compile" => Ok(Box::new(Compile { arg, flags })),
-        "run" => Ok(Box::new(Run { arg, flags })),
+        "help" | "" => Ok(Box::new(Help::new(arg, flags))),
+        "version" => Ok(Box::new(Version::new(arg, flags))),
+        "lex" => Ok(Box::new(Lex::new(arg, flags))),
+        "parse" => Ok(Box::new(Parse::new(arg, flags))),
+        "analyze" => Ok(Box::new(Analyze::new(arg, flags))),
+        "compile" => Ok(Box::new(Compile::new(arg, flags))),
+        "run" => Ok(Box::new(Run::new(arg, flags))),
         _ => Err(format!("Unknown command {}", name)),
     }
 }
-pub fn tokenize(args: Vec<String>) -> Result<Box<dyn Command>, String> {
+/// collects the os args into easily parsable parts:
+/// - the command
+/// - the argument
+/// - flags
+/// in that order. This means that flags cannot come before the argument
+pub fn parse_args(args: Vec<String>) -> Result<Box<dyn Command>, String> {
     let mut args_iter = args.into_iter();
     let command = args_iter.next().unwrap_or_default();
     let arg = args_iter.next().unwrap_or_default();

--- a/src/cli/compile.rs
+++ b/src/cli/compile.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::{
     cli::commands::Command,
@@ -6,10 +6,18 @@ use crate::{
 };
 
 pub struct Compile {
-    pub arg: String,
-    pub flags: Option<Vec<String>>,
+    arg: String,
+    path: PathBuf,
+    flags: Option<Vec<String>>,
 }
 impl Command for Compile {
+    fn new(arg: String, flags: Option<Vec<String>>) -> Self {
+        Self {
+            arg,
+            path: "".into(),
+            flags,
+        }
+    }
     fn help_msg(verbose: bool) {
         let mut title = "compile".pad_right(16).fill_left(2).bold();
         if verbose {
@@ -29,15 +37,17 @@ impl Command for Compile {
             );
         }
     }
-    fn parse(&self) -> Result<(), String> {
-        Path::new(&self.arg)
+    fn validate(&mut self) -> Result<(), String> {
+        self.path = Path::new(&self.arg)
             .canonicalize()
             .map_err(|_| format!("Failed to canonicalize path: '{}'", self.arg))?
-            .must_be_file()?
+            .must_be_file()?;
+        self.path
             .extension()
             .map_or(false, |ext| ext == "uwu")
             .then(|| ())
-            .ok_or(format!("\"{}\" is not a .uwu file", self.arg))
+            .ok_or(format!("\"{}\" is not a .uwu file", self.arg))?;
+        Ok(())
     }
     fn exec(&self) -> Result<(), String> {
         todo!()

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -7,10 +7,16 @@ use crate::{
 };
 
 pub struct Help {
-    pub arg: String,
-    pub flags: Option<Vec<String>>,
+    arg: String,
+    flags: Option<Vec<String>>,
 }
 impl Command for Help {
+    fn new(arg: String, flags: Option<Vec<String>>) -> Self
+    where
+        Self: Sized,
+    {
+        Self { arg, flags }
+    }
     fn help_msg(verbose: bool) {
         let mut title = "help".pad_right(16).fill_left(2).bold();
         if verbose {
@@ -29,7 +35,7 @@ impl Command for Help {
             println!("{}", "owo help help".fill_left(18));
         }
     }
-    fn parse(&self) -> Result<(), String> {
+    fn validate(&mut self) -> Result<(), String> {
         match self.arg.as_str() {
             "" | "help" | "lex" | "parse" | "analyze" | "compile" | "run" | "version" => Ok(()),
             _ => Err(format!(

--- a/src/cli/lex.rs
+++ b/src/cli/lex.rs
@@ -1,4 +1,7 @@
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     cli::commands::Command,
@@ -7,10 +10,18 @@ use crate::{
 };
 
 pub struct Lex {
-    pub arg: String,
-    pub flags: Option<Vec<String>>,
+    arg: String,
+    path: PathBuf,
+    flags: Option<Vec<String>>,
 }
 impl Command for Lex {
+    fn new(arg: String, flags: Option<Vec<String>>) -> Self {
+        Self {
+            arg,
+            path: "".into(),
+            flags,
+        }
+    }
     fn help_msg(verbose: bool) {
         let title = "lex".pad_right(16).fill_left(2).bold();
         println!(
@@ -27,15 +38,17 @@ impl Command for Lex {
             );
         }
     }
-    fn parse(&self) -> Result<(), String> {
-        Path::new(&self.arg)
+    fn validate(&mut self) -> Result<(), String> {
+        self.path = Path::new(&self.arg)
             .canonicalize()
             .map_err(|_| format!("Failed to canonicalize path: '{}'", self.arg))?
-            .must_be_file()?
+            .must_be_file()?;
+        self.path
             .extension()
             .map_or(false, |ext| ext == "uwu")
             .then(|| ())
-            .ok_or(format!("\"{}\" is not a .uwu file", self.arg))
+            .ok_or(format!("\"{}\" is not a .uwu file", self.arg))?;
+        Ok(())
     }
     fn exec(&self) -> Result<(), String> {
         let abs_path = Path::new(&self.arg)

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -3,13 +3,21 @@ use crate::{
     utils::{path::PathExt, string::StringExt},
 };
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub struct Run {
-    pub arg: String,
-    pub flags: Option<Vec<String>>,
+    arg: String,
+    path: PathBuf,
+    flags: Option<Vec<String>>,
 }
 impl Command for Run {
+    fn new(arg: String, flags: Option<Vec<String>>) -> Self {
+        Self {
+            arg,
+            path: "".into(),
+            flags,
+        }
+    }
     fn help_msg(verbose: bool) {
         let mut title = "run".pad_right(16).fill_left(2).bold();
         if verbose {
@@ -29,15 +37,17 @@ impl Command for Run {
             );
         }
     }
-    fn parse(&self) -> Result<(), String> {
-        Path::new(&self.arg)
+    fn validate(&mut self) -> Result<(), String> {
+        self.path = Path::new(&self.arg)
             .canonicalize()
             .map_err(|_| format!("Failed to canonicalize path: '{}'", self.arg))?
-            .must_be_file()?
+            .must_be_file()?;
+        self.path
             .extension()
             .map_or(false, |ext| ext == "uwu")
             .then(|| ())
-            .ok_or(format!("\"{}\" is not a .uwu file", self.arg))
+            .ok_or(format!("\"{}\" is not a .uwu file", self.arg))?;
+        Ok(())
     }
     fn exec(&self) -> Result<(), String> {
         todo!()

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -5,6 +5,9 @@ pub struct Version {
     pub flags: Option<Vec<String>>,
 }
 impl Command for Version {
+    fn new(arg: String, flags: Option<Vec<String>>) -> Self {
+        Self { arg, flags }
+    }
     fn help_msg(verbose: bool) {
         let mut title = "version".pad_right(16).fill_left(2).bold();
         if verbose {
@@ -24,7 +27,7 @@ impl Command for Version {
             );
         }
     }
-    fn parse(&self) -> Result<(), String> {
+    fn validate(&mut self) -> Result<(), String> {
         match self.arg.as_str() {
             "" => Ok(()),
             _ => Err(format!("'version' takes no arguments, got '{}'", self.arg)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,8 @@ mod tests;
 mod utils;
 
 fn main() {
-    let os_args: Vec<String> = std::env::args().skip(1).collect();
-    cli::commands::tokenize(os_args)
-        .and_then(|cmd| cmd.parse().map(move |_| cmd))
+    cli::commands::parse_args(std::env::args().skip(1).collect())
+        .and_then(|mut cmd| cmd.validate().map(move |_| cmd))
         .and_then(|cmd| cmd.exec())
-        .unwrap_or_else(|e| println!("{}", e));
+        .unwrap_or_else(|e| println!("{e}"));
 }


### PR DESCRIPTION
## changes
1. Command has new to enforce at least an `arg` and a `flags` field. Implementors can declare other fields as well
2. . This validates the `arg` and `flags`, which then the command can assign the validated values to other fields
    - This is because currently, it takes in a `&self` and does not assign fields. This leads to double validation in `Command::exec()`
3. all commands related to the compilation process now has a `path` field which `Command::validate()` assigns the validated `arg` to

## etc
1. rename `Command::parse()` to `Command::validate()`
2. rename `tokenize()` to `parse_args()`
